### PR TITLE
Default to no config file

### DIFF
--- a/src/cliap2.c
+++ b/src/cliap2.c
@@ -148,17 +148,17 @@ usage(char *program)
   printf("  --logfile <filename>      Log filename. Not supplying this argument will result in logging to stderr only.\n");
   printf("  --logdomains <dom,dom..>  Log domains\n");
   printf("  --config <file>           Use <file> as the configuration file\n");
-  printf("  --name <name>             Name of the airplay 2 device\n");
-  printf("  --hostname <hostname>     Hostname of AirPlay 2 device\n");
-  printf("  --address <address>       IP address to bind to for AirPlay 2 service\n");
-  printf("  --port <port>             Port number to bind to for AirPlay 2 service\n");
-  printf("  --txt <txt>               txt keyvals returned in mDNS for AirPlay 2 service\n");
-  printf("  --pipe                    filename of named pipe to read streamed audio\n");
-  printf("  --ntp                     Print current NTP time and exit\n");
+  printf("  --name <name>             Name of the airplay 2 device. Mandatory in absence of --ntpstart.\n");
+  printf("  --hostname <hostname>     Hostname of AirPlay 2 device. Mandatory in absence of --ntpstart.\n");
+  printf("  --address <address>       IP address to bind to for AirPlay 2 service. Mandatory in absence of --ntpstart.\n");
+  printf("  --port <port>             Port number to bind to for AirPlay 2 service. Mandatory in absence of --ntpstart.\n");
+  printf("  --txt <txt>               txt keyvals returned in mDNS for AirPlay 2 service. Mandatory in absence of --ntpstart.\n");
+  printf("  --pipe                    filename of named pipe to read streamed audio. Mandatory in absence of --ntpstart.\n");
+  printf("  --ntp                     Print current NTP time and exit.\n");
   printf("  --wait                    Start playback after <wait> milliseconds\n");
-  printf("  --ntpstart                Start playback at NTP <start> + <wait>\n");
+  printf("  --ntpstart                Start playback at NTP <start> + <wait>. Mandatory in absence of --ntpstart.\n");
   printf("  --latency                 Latency to apply in frames\n");
-  printf("  --volume                  Initial volume (0-100)\n");
+  printf("  --volume                  Initial volume (0-100). Mandatory in absence of --ntpstart.\n");
   printf("  -v, --version             Display version information and exit\n");
   printf("\n\n");
   printf("Available log domains:\n");
@@ -488,7 +488,7 @@ int
 main(int argc, char **argv)
 {
   int option;
-  char *configfile = CONFFILE;
+  char *configfile = NULL; // default to no config file
   bool background = false;
   bool testrun = false;
   bool mdns_no_rsp = true;
@@ -670,7 +670,6 @@ main(int argc, char **argv)
 
     return EXIT_FAILURE;
   }
-  // logger_detach();  // Eliminate logging to stderr
 
   ret = conffile_load(configfile);
   if (ret != 0) {

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -396,20 +396,22 @@ conffile_load(char *file)
 
   cfg_set_error_function(cfg, logger_confuse);
 
-  ret = cfg_parse(cfg, file);
+  if (file) { // makes config file optional
+    ret = cfg_parse(cfg, file);
 
-  if (ret == CFG_FILE_ERROR)
-    {
-      DPRINTF(E_FATAL, L_CONF, "Could not open config file %s\n", file);
+    if (ret == CFG_FILE_ERROR)
+      {
+        DPRINTF(E_FATAL, L_CONF, "Could not open config file %s\n", file);
 
-      goto out_fail;
-    }
-  else if (ret == CFG_PARSE_ERROR)
-    {
-      DPRINTF(E_FATAL, L_CONF, "Parse error in config file %s\n", file);
+        goto out_fail;
+      }
+    else if (ret == CFG_PARSE_ERROR)
+      {
+        DPRINTF(E_FATAL, L_CONF, "Parse error in config file %s\n", file);
 
-      goto out_fail;
-    }
+        goto out_fail;
+      }
+  }
 
   return 0;
 


### PR DESCRIPTION
Improve usage output so it is clear which arguments are mandatory.

Allow, and default, to no config file. If a config file is desired, it needs to be specified with the `--config` command line argument.