### PR TITLE
Command/Metadata named pipe filename via argument

### DIFF
--- a/src/cliap2.h
+++ b/src/cliap2.h
@@ -1,6 +1,8 @@
 #ifndef __CLIAP2_H__
 #define __CLIAP2_H__
 
+#define METADATA_NAMED_PIPE_DEFAULT_SUFFIX ".metadata"
+
 typedef struct ap2_device_info
 {
   const char *name;
@@ -14,5 +16,11 @@ typedef struct ap2_device_info
   uint32_t latency;
   int volume;
 } ap2_device_info_t;
+
+typedef struct mass_named_pipes
+{
+  char *audio_pipe; // receives raw pcm audio to be streamed
+  char *metadata_pipe; // receives metadata and commands
+} mass_named_pipes_t;
 
 #endif /* !__CLIAP2_H__ */

--- a/src/mass.c
+++ b/src/mass.c
@@ -94,7 +94,7 @@
 #define MASS_METADATA_ACTION_KEY    "ACTION"
 
 /* from cliap2.c */
-extern char* gnamed_pipe;
+extern mass_named_pipes_t mass_named_pipes;
 extern struct event_base *evbase_main;
 
 /* from player.c */
@@ -1325,7 +1325,7 @@ pipe_metadata_watch_add(void *arg)
   char path[PATH_MAX];
   int ret;
 
-  ret = snprintf(path, sizeof(path), "%s.metadata", base_path);
+  ret = snprintf(path, sizeof(path), "%s", base_path);
   if ((ret < 0) || (ret > sizeof(path)))
     return;
 
@@ -1390,9 +1390,9 @@ pipelist_create(void)
   int id;
   int ret;
 
-  DPRINTF(E_DBG, L_PLAYER, "Adding %s to the pipelist\n", gnamed_pipe);
+  DPRINTF(E_DBG, L_PLAYER, "Adding %s to the pipelist\n", mass_named_pipes.audio_pipe);
   head = NULL;
-  pipe = pipe_create(gnamed_pipe, 1, PIPE_PCM, pipe_read_cb);
+  pipe = pipe_create(mass_named_pipes.audio_pipe, 1, PIPE_PCM, pipe_read_cb);
   pipelist_add(&head, pipe);
 
   return head;
@@ -1450,7 +1450,9 @@ setup(struct input_source *source)
   pipe->fd = fd;
   pipe->is_autostarted = (source->id == pipe_autostart_id);
 
-  worker_execute(pipe_metadata_watch_add, source->path, strlen(source->path) + 1, 0);
+  // We override default owntones behaviour and allow specification of the metadata named pipe
+  worker_execute(pipe_metadata_watch_add, mass_named_pipes.metadata_pipe, strlen(mass_named_pipes.metadata_pipe) + 1, 0);
+  // worker_execute(pipe_metadata_watch_add, source->path, strlen(source->path) + 1, 0);
 
   source->input_ctx = pipe;
 

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -35,7 +35,7 @@
 #define AIRPLAY_SERVICE_TYPE "_airplay._tcp"
 
 extern ap2_device_info_t ap2_device_info;
-extern char* gnamed_pipe;
+extern mass_named_pipes_t mass_named_pipes;
 
 /*
  * Wrappers for db.c
@@ -309,7 +309,7 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id,
             item->shuffle_pos = 1;
             item->data_kind = DATA_KIND_PIPE; // this is all we support for the moment
             item->media_kind = MEDIA_KIND_MUSIC; // we only support audio
-            item->path = gnamed_pipe;
+            item->path = mass_named_pipes.audio_pipe;
             item->bitrate = 0; // I don't think value matters for us.
             item->samplerate = cfg_getint(cfg_getsec(cfg, "mass"), "pcm_sample_rate");
             item->channels = 2;


### PR DESCRIPTION
`--command_pipe <filename>` is now a supported command line argument. 
If it is supplied, then this filename of the named pipe that will be used for reading and processing commands and metadata.
If it is not supplied, then the the commands/metadata named pipe filename will default to `<audio_named_pipe>.metadata`. Where `<audio_named_pipe>` is the filename supplied to the `--pipe` command line argument.