### PR TITLE
Gracefully exit on receipt of STOP command

### DIFF
--- a/src/mass.c
+++ b/src/mass.c
@@ -1303,7 +1303,8 @@ pipe_metadata_read_cb(evutil_socket_t fd, short event, void *arg)
   }
   if (message & PIPE_METADATA_MSG_STOP) {
     DPRINTF(E_DBG, L_PLAYER, "%s:Stopping playback from metadata pipe command\n", __func__);
-    player_playback_stop();
+    // We want to gracefully exit when we receive the STOP command.
+    event_base_loopbreak(evbase_main);
   }
 
  readd:


### PR DESCRIPTION
We break the main event loop, which triggers graceful shutdown and exit, upon receipt of STOP command on the command/metadata named pipe.