### PR TITLE
Implementation of PIN-based pairing

### DIFF
--- a/src/airplay.c
+++ b/src/airplay.c
@@ -3972,9 +3972,6 @@ airplay_device_authorize(struct output_device *device, const char *pin, int call
   if (!rs)
     return -1;
 
-  DPRINTF(E_DBG, L_AIRPLAY, "%s:Calling sequence_start(AIRPLAY_SEQ_PAIR_SETUP,...) for %s with PIN %s\n",
-    __func__, device->name, pin
-  );
   sequence_start(AIRPLAY_SEQ_PAIR_SETUP, rs, (void *)pin, "device_authorize");
 
   return 1;

--- a/src/cliap2.c
+++ b/src/cliap2.c
@@ -147,12 +147,13 @@ usage(char *program)
   printf("  --loglevel <number>               Log level (0-5)\n");
   printf("  --logfile <filename>              Log filename. Not supplying this argument will result in logging to stderr only.\n");
   printf("  --logdomains <dom,dom..>          Log domains\n");
-  printf("  --config <file>                   Use <file> as the configuration file\n");
+  printf("  --config <file>                   Use <file> for the configuration file.\n");
   printf("  --name <name>                     Name of the airplay 2 device. Mandatory in absence of --ntpstart.\n");
   printf("  --hostname <hostname>             Hostname of AirPlay 2 device. Mandatory in absence of --ntpstart.\n");
   printf("  --address <address>               IP address to bind to for AirPlay 2 service. Mandatory in absence of --ntpstart.\n");
   printf("  --port <port>                     Port number to bind to for AirPlay 2 service. Mandatory in absence of --ntpstart.\n");
   printf("  --txt <txt>                       txt keyvals returned in mDNS for AirPlay 2 service. Mandatory in absence of --ntpstart.\n");
+  printf("  --auth <auth_key>                 Authorization key.\n");
   printf("  --pipe <audio_filename>           filename of named pipe to read streamed audio. Mandatory in absence of --ntpstart.\n");
   printf("  --command_pipe <command_filename> filename of named pipe to read commands and metadata. Defaults to <audio_filename>.metadata\n");
   printf("  --ntp                             Print current NTP time and exit.\n");
@@ -524,6 +525,7 @@ main(int argc, char **argv)
     { "testrun",       0, NULL, 514 }, // Used for CI, not documented to user
     { "pipe",          1, NULL, 515 },
     { "command_pipe",  1, NULL, 517 },
+    { "auth",          1, NULL, 518 },
 
     { NULL,            0, NULL, 0   }
   };
@@ -629,6 +631,10 @@ main(int argc, char **argv)
         mass_named_pipes.metadata_pipe = optarg;
         break;
 
+      case 518: // authorization key
+        ap2_device_info.auth_key = optarg;
+        break;
+
         default:
       case '?':
         usage(argv[0]);
@@ -683,7 +689,6 @@ main(int argc, char **argv)
     conffile_unload();
     return EXIT_FAILURE;
   }
-  // logger_detach();  // Eliminate logging to stderr
 
   if (testrun) {
     ret = create_pipes(TESTRUN_PIPE);
@@ -694,7 +699,7 @@ main(int argc, char **argv)
     mass_named_pipes.audio_pipe = TESTRUN_PIPE;
   }
   else {
-    // Check that named pipe exists for audio streaming. Metadata one too?
+    // Check that named pipes exist for audio streaming and metadata
     ret = check_pipe(mass_named_pipes.audio_pipe);
     if (ret < 0) {
       return EXIT_FAILURE;

--- a/src/cliap2.h
+++ b/src/cliap2.h
@@ -10,6 +10,7 @@ typedef struct ap2_device_info
   const char *address;
   int port;
   struct keyval *txt;
+  const char *auth_key;
   uint64_t ntpstart;
   uint32_t wait;
   struct timespec start_ts;

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -52,7 +52,7 @@ static cfg_opt_t sec_general[] =
     CFG_STR_LIST("trusted_networks", "{lan}", CFGF_NONE),
     CFG_BOOL("ipv6", cfg_false, CFGF_NONE),
     CFG_STR("bind_address", NULL, CFGF_NONE),
-    CFG_BOOL("speaker_autoselect", cfg_false, CFGF_NONE),
+    CFG_BOOL("speaker_autoselect", cfg_true, CFGF_NONE),
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
     CFG_BOOL("high_resolution_clock", cfg_false, CFGF_NONE),
 #else
@@ -70,7 +70,7 @@ static cfg_opt_t sec_general[] =
 /* library section structure */
 static cfg_opt_t sec_library[] =
   {
-    CFG_STR("name", "My Music on %h", CFGF_NONE),
+    CFG_STR("name", "Music Assistant", CFGF_NONE),
     CFG_INT("port", 3689, CFGF_NONE),
     CFG_STR("password", NULL, CFGF_NONE),
     CFG_STR_LIST("directories", NULL, CFGF_NONE),

--- a/src/player.h
+++ b/src/player.h
@@ -203,6 +203,9 @@ player_device_remove(void *device);
 void
 player_raop_verification_kickoff(char **arglist);
 
+void
+player_verification_kickoff(char **arglist, enum output_types type);
+
 const char *
 player_pmap(void *p);
 

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -387,7 +387,11 @@ db_perthread_deinit(void)
 int
 db_speaker_save(struct output_device *device)
 {
-    // It has been tested that it is ok to do nothing
+    if (device->auth_key) {
+        DPRINTF(E_DBG, L_DB, "%s:Device %s has authorization key '%s'\n", 
+            __func__, device->name, device->auth_key
+        );
+    }
     return 0;
 }
 
@@ -397,7 +401,7 @@ db_speaker_get(struct output_device *device, uint64_t id)
     device->id = id;
     device->selected = 1;
     device->volume = ap2_device_info.volume;
-    //device->auth_key = ?? // might need to pass this as command line argument for some devices
+    device->auth_key = (char *)ap2_device_info.auth_key; // lose the const qualifier
     device->selected_format = MEDIA_FORMAT_ALAC;
 
     return 0;
@@ -472,6 +476,12 @@ db_escape_string(const char *str)
 /*
  * Wrappers for mdns.c
  */
+
+ // Immediately call the mdns_browse_cb with the information about the 
+ // airplay device we want to stream to.
+ // TODO: @bradkeifer - see if we can trigger device connection after
+ // the callback is complete. At the moment, device connection is triggered 
+ // on receipt of first audio streaming data on the named pipe.
 int
 mdns_browse(char *type, mdns_browse_cb cb, enum mdns_options flags)
 {


### PR DESCRIPTION
Initial work to support PIN-based pairing to devices such as Apple TV's.
This is not yet functional. 
The next step is to work out where in the code (that we will maintain) we can detect that a PIN is required and then prevent, or skip, playback until the PIN-pairing is completed.
The PIN is to be sent to the command named pipe with the command `"PIN=XXXX"`, where `XXXX` is the 4 digit pin.
