### PR TITLE
44 review and validate metadata processing

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1462,10 +1462,13 @@ device_remove_family(void *arg, int *retval)
       // backend gives us a callback with a failure. Then outputs.c will remove
       // the device. If the output backend never gives a callback (can that
       // happen?) then the device will never be removed.
-      if (!device->session)
+      if (!device->session) {
+        DPRINTF(E_DBG, L_PLAYER, "%s:No v4 address, no v6 address and no session. Removing device\n", __func__);
 	outputs_device_remove(device);
+      }
     }
 
+  DPRINTF(E_DBG, L_PLAYER, "%s:About to call outputs_device_free() for %s\n", __func__, remove->name);
   outputs_device_free(remove);
 
   status_update(player_state, LISTENER_SPEAKER | LISTENER_VOLUME);


### PR DESCRIPTION
Significant improvements to the methods employed for handling playback related commands. Refer to this [discussion](https://github.com/owntone/owntone-server/issues/1939) on the appropriate mechanisms within the owntones design for communication between modules.

This addresses issues #19 and #44 but there is still an issue related to #19. The cause of this issue appears to be because of the method used to handle the NTP start time at original commencement of streaming. That method requires re-engineering so that it is only used at the commencement of original streaming. That work will be managed under a separate issue and branch.