### PR TITLE
Serious bug affecting testrun.

### DIFF
--- a/src/cliap2.c
+++ b/src/cliap2.c
@@ -698,6 +698,7 @@ main(int argc, char **argv)
       return EXIT_FAILURE;
     }
     mass_named_pipes.audio_pipe = TESTRUN_PIPE;
+    mass_named_pipes.metadata_pipe = TESTRUN_PIPE METADATA_NAMED_PIPE_DEFAULT_SUFFIX;
   }
   else {
     // Check that named pipes exist for audio streaming and metadata


### PR DESCRIPTION
We were missing definition of the named pipe filename for the metadata named pipe when executing a testrun.