### PR TITLE
Enable password parameter to bypass owntone constraint

### DIFF
--- a/src/cliap2.c
+++ b/src/cliap2.c
@@ -216,7 +216,7 @@ usage(char *program)
   printf("  --ntpstart <NTP>                  Start playback at NTP. Mandatory in absence of --ntp.\n");
   printf("  --volume <volume>                 Initial volume (0-100). Defaults to 0\n");
   printf("  --latency <latency>               ms of data to buffer in the output buffer. Defaults to 2000\n");
-  // printf("  --password <password>             Device password.\n");
+  printf("  --password <password>             Device password.\n");
   printf("  -v, --version                     Display version information and exit\n");
   printf("\n\n");
 }
@@ -553,7 +553,7 @@ main(int argc, char **argv)
     { "auth",          1, NULL, 515 },
     { "dacp_id",       1, NULL, 516 },
     { "latency",       1, NULL, 517 },
-    // { "password",      1, NULL, 518 },
+    { "password",      1, NULL, 518 },
 
     { NULL,            0, NULL, 0   }
   };
@@ -667,9 +667,9 @@ main(int argc, char **argv)
         DPRINTF(E_DBG, L_MAIN, "Latency set to %" PRIu64 " ms inclusive of 250ms DAC latency\n", latency_ms);
         break;
 
-      // case 518: // device password
-      //   ap2_device_info.password = optarg;
-      //   break;
+      case 518: // device password
+        ap2_device_info.password = strdup(optarg);
+        break;
 
       default:
       case '?':


### PR DESCRIPTION
Owntone airplay.c requires that a password be supplied when pairing is password based, even when a token is provided. In order to avoid making changes to the git module (under control of owntone) I am uncommenting the pre-existing password parameter. This parameter does not work in the sense that pairing doesn't work, but if a token is supplied as well, it's sufficient to enable streaming as owntone uses the token and ignores the password.