### PR TITLE
Add deprecation note - replaced by airplay-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> **This repository is deprecated and archived.** Music Assistant now streams to AirPlay devices with the unified [airplay-cli](https://github.com/music-assistant/airplay-cli) binary, which replaces both this AirPlay 2 client (cliap2) and the RAOP client (CLIRaop).
+
 # cliairplay
 
 Command line interface for audio streaming to AirPlay 2 devices


### PR DESCRIPTION
This repo (cliap2) is superseded by the unified airplay-cli binary. Adding a README note before archiving the repo.